### PR TITLE
Added library.properties for Arduino IDE

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,8 @@
+name=base64
+version=1.0.0
+author=Adam Rudd
+maintainer=Adam Rudd
+sentence=A base64 library for the arduino platform, written in C
+category=Data Processing
+url=https://github.com/adamvr/arduino-base64
+architectures=*


### PR DESCRIPTION
The Arduino IDE can import libraries, and if a library.properties file is present, then it uses that to determine the library's name and such. See https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification for details
